### PR TITLE
Trivial fix to make it run fine on Windows/MSYS2 too

### DIFF
--- a/em6502.c
+++ b/em6502.c
@@ -373,7 +373,7 @@ void cpu_reset(void) {
 }
 
 int rom1_load() {
-   FILE *f = fopen("rom1.img","r");
+   FILE *f = fopen("rom1.img","rb");
    if(f == NULL) {
       fprintf(stderr, "Unable to open 'rom.img'\n");
       return 0;
@@ -388,7 +388,7 @@ int rom1_load() {
 }
 
 int rom2_load() {
-   FILE *f = fopen("rom2.img","r");
+   FILE *f = fopen("rom2.img","rb");
    if(f == NULL) {
       fprintf(stderr, "Unable to open 'rom.img'\n");
       return 0;


### PR DESCRIPTION
This is a (very) trivial fix to make it run fine on Windows/MSYS2, too.

The root cause is that the original code of rom1_load and rom2_load fail to read the requested number of bytes.
This is due to the fact that, on Windows, opening binary files as text (fopen + "r") make it convert the CR/LF characters.

So opening with "rb" instead (doesn't change anything on unix/linux environments) make it work.